### PR TITLE
fix issue 37

### DIFF
--- a/api/v1/oas_json_gen.go
+++ b/api/v1/oas_json_gen.go
@@ -512,114 +512,69 @@ func (s *GetPersonRequest) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s *IdRef) Encode(e *jx.Encoder) {
+func (s IdRefs) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
 	e.ObjEnd()
 }
 
-// encodeFields encodes fields.
-func (s *IdRef) encodeFields(e *jx.Encoder) {
-	{
-		e.FieldStart("id")
-		e.Str(s.ID)
-	}
-	{
-		e.FieldStart("type")
-		e.Str(s.Type)
-	}
-}
+// encodeFields implements json.Marshaler.
+func (s IdRefs) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
 
-var jsonFieldsNameOfIdRef = [2]string{
-	0: "id",
-	1: "type",
-}
-
-// Decode decodes IdRef from json.
-func (s *IdRef) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode IdRef to nil")
-	}
-	var requiredBitSet [1]uint8
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "id":
-			requiredBitSet[0] |= 1 << 0
-			if err := func() error {
-				v, err := d.Str()
-				s.ID = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"id\"")
-			}
-		case "type":
-			requiredBitSet[0] |= 1 << 1
-			if err := func() error {
-				v, err := d.Str()
-				s.Type = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"type\"")
-			}
-		default:
-			return d.Skip()
+		e.ArrStart()
+		for _, elem := range elem {
+			e.Str(elem)
 		}
+		e.ArrEnd()
+	}
+}
+
+// Decode decodes IdRefs from json.
+func (s *IdRefs) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode IdRefs to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem []string
+		if err := func() error {
+			elem = make([]string, 0)
+			if err := d.Arr(func(d *jx.Decoder) error {
+				var elemElem string
+				v, err := d.Str()
+				elemElem = string(v)
+				if err != nil {
+					return err
+				}
+				elem = append(elem, elemElem)
+				return nil
+			}); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode IdRef")
-	}
-	// Validate required fields.
-	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b00000011,
-	} {
-		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
-			// Mask only required fields and check equality to mask using XOR.
-			//
-			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
-			// Bits of fields which would be set are actually bits of missed fields.
-			missed := bits.OnesCount8(result)
-			for bitN := 0; bitN < missed; bitN++ {
-				bitIdx := bits.TrailingZeros8(result)
-				fieldIdx := i*8 + bitIdx
-				var name string
-				if fieldIdx < len(jsonFieldsNameOfIdRef) {
-					name = jsonFieldsNameOfIdRef[fieldIdx]
-				} else {
-					name = strconv.Itoa(fieldIdx)
-				}
-				failures = append(failures, validate.FieldError{
-					Name:  name,
-					Error: validate.ErrFieldRequired,
-				})
-				// Reset bit.
-				result &^= 1 << bitIdx
-			}
-		}
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
+		return errors.Wrap(err, "decode IdRefs")
 	}
 
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *IdRef) MarshalJSON() ([]byte, error) {
+func (s IdRefs) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *IdRef) UnmarshalJSON(data []byte) error {
+func (s *IdRefs) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -657,6 +612,40 @@ func (s OptDateTime) MarshalJSON() ([]byte, error) {
 func (s *OptDateTime) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d, json.DecodeDateTime)
+}
+
+// Encode encodes IdRefs as json.
+func (o OptIdRefs) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes IdRefs from json.
+func (o *OptIdRefs) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptIdRefs to nil")
+	}
+	o.Set = true
+	o.Value = make(IdRefs)
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptIdRefs) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptIdRefs) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
 }
 
 // Encode encodes PersonSettings as json.
@@ -778,13 +767,9 @@ func (s *Organization) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.OtherID != nil {
+		if s.OtherID.Set {
 			e.FieldStart("other_id")
-			e.ArrStart()
-			for _, elem := range s.OtherID {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
+			s.OtherID.Encode(e)
 		}
 	}
 }
@@ -900,15 +885,8 @@ func (s *Organization) Decode(d *jx.Decoder) error {
 			}
 		case "other_id":
 			if err := func() error {
-				s.OtherID = make([]IdRef, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem IdRef
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.OtherID = append(s.OtherID, elem)
-					return nil
-				}); err != nil {
+				s.OtherID.Reset()
+				if err := s.OtherID.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -1351,13 +1329,9 @@ func (s *Person) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.OtherID != nil {
+		if s.OtherID.Set {
 			e.FieldStart("other_id")
-			e.ArrStart()
-			for _, elem := range s.OtherID {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
+			s.OtherID.Encode(e)
 		}
 	}
 	{
@@ -1608,15 +1582,8 @@ func (s *Person) Decode(d *jx.Decoder) error {
 			}
 		case "other_id":
 			if err := func() error {
-				s.OtherID = make([]IdRef, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem IdRef
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.OtherID = append(s.OtherID, elem)
-					return nil
-				}); err != nil {
+				s.OtherID.Reset()
+				if err := s.OtherID.Decode(d); err != nil {
 					return err
 				}
 				return nil

--- a/api/v1/oas_schemas_gen.go
+++ b/api/v1/oas_schemas_gen.go
@@ -137,30 +137,16 @@ func (s *GetPersonRequest) SetID(val string) {
 	s.ID = val
 }
 
-// Ref: #/components/schemas/IdRef
-type IdRef struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
+// Ref: #/components/schemas/IdRefs
+type IdRefs map[string][]string
 
-// GetID returns the value of ID.
-func (s *IdRef) GetID() string {
-	return s.ID
-}
-
-// GetType returns the value of Type.
-func (s *IdRef) GetType() string {
-	return s.Type
-}
-
-// SetID sets the value of ID.
-func (s *IdRef) SetID(val string) {
-	s.ID = val
-}
-
-// SetType sets the value of Type.
-func (s *IdRef) SetType(val string) {
-	s.Type = val
+func (s *IdRefs) init() IdRefs {
+	m := *s
+	if m == nil {
+		m = map[string][]string{}
+		*s = m
+	}
+	return m
 }
 
 // NewOptDateTime returns new OptDateTime with value set to v.
@@ -203,6 +189,52 @@ func (o OptDateTime) Get() (v time.Time, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptDateTime) Or(d time.Time) time.Time {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptIdRefs returns new OptIdRefs with value set to v.
+func NewOptIdRefs(v IdRefs) OptIdRefs {
+	return OptIdRefs{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptIdRefs is optional IdRefs.
+type OptIdRefs struct {
+	Value IdRefs
+	Set   bool
+}
+
+// IsSet returns true if OptIdRefs was set.
+func (o OptIdRefs) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptIdRefs) Reset() {
+	var v IdRefs
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptIdRefs) SetTo(v IdRefs) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptIdRefs) Get() (v IdRefs, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptIdRefs) Or(d IdRefs) IdRefs {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -311,7 +343,7 @@ type Organization struct {
 	NameDut     OptString `json:"name_dut"`
 	NameEng     OptString `json:"name_eng"`
 	ParentID    OptString `json:"parent_id"`
-	OtherID     []IdRef   `json:"other_id"`
+	OtherID     OptIdRefs `json:"other_id"`
 }
 
 // GetID returns the value of ID.
@@ -355,7 +387,7 @@ func (s *Organization) GetParentID() OptString {
 }
 
 // GetOtherID returns the value of OtherID.
-func (s *Organization) GetOtherID() []IdRef {
+func (s *Organization) GetOtherID() OptIdRefs {
 	return s.OtherID
 }
 
@@ -400,7 +432,7 @@ func (s *Organization) SetParentID(val OptString) {
 }
 
 // SetOtherID sets the value of OtherID.
-func (s *Organization) SetOtherID(val []IdRef) {
+func (s *Organization) SetOtherID(val OptIdRefs) {
 	s.OtherID = val
 }
 
@@ -506,7 +538,7 @@ type Person struct {
 	PreferredLastName  OptString         `json:"preferred_last_name"`
 	BirthDate          OptString         `json:"birth_date"`
 	Title              OptString         `json:"title"`
-	OtherID            []IdRef           `json:"other_id"`
+	OtherID            OptIdRefs         `json:"other_id"`
 	Organization       []OrganizationRef `json:"organization"`
 	JobCategory        []string          `json:"job_category"`
 	Role               []string          `json:"role"`
@@ -591,7 +623,7 @@ func (s *Person) GetTitle() OptString {
 }
 
 // GetOtherID returns the value of OtherID.
-func (s *Person) GetOtherID() []IdRef {
+func (s *Person) GetOtherID() OptIdRefs {
 	return s.OtherID
 }
 
@@ -701,7 +733,7 @@ func (s *Person) SetTitle(val OptString) {
 }
 
 // SetOtherID sets the value of OtherID.
-func (s *Person) SetOtherID(val []IdRef) {
+func (s *Person) SetOtherID(val OptIdRefs) {
 	s.OtherID = val
 }
 

--- a/api/v1/oas_validators_gen.go
+++ b/api/v1/oas_validators_gen.go
@@ -64,11 +64,76 @@ func (s *GetPersonRequest) Validate() error {
 	return nil
 }
 
+func (s IdRefs) Validate() error {
+	var failures []validate.FieldError
+	for key, elem := range s {
+		if err := func() error {
+			if elem == nil {
+				return errors.New("nil is invalid value")
+			}
+			return nil
+		}(); err != nil {
+			failures = append(failures, validate.FieldError{
+				Name:  key,
+				Error: err,
+			})
+		}
+	}
+
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *Organization) Validate() error {
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.OtherID.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "other_id",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *OrganizationListResponse) Validate() error {
 	var failures []validate.FieldError
 	if err := func() error {
 		if s.Data == nil {
 			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.Data {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
 		}
 		return nil
 	}(); err != nil {
@@ -83,11 +148,54 @@ func (s *OrganizationListResponse) Validate() error {
 	return nil
 }
 
+func (s *Person) Validate() error {
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.OtherID.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "other_id",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *PersonListResponse) Validate() error {
 	var failures []validate.FieldError
 	if err := func() error {
 		if s.Data == nil {
 			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.Data {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
 		}
 		return nil
 	}(); err != nil {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -250,14 +250,12 @@ components:
         - code
         - message
 
-    IdRef:
+    IdRefs:
       type: object
-      properties:
-        id:
+      additionalProperties:
+        type: array
+        items:
           type: string
-        type:
-          type: string
-      required: [id, type]
 
     OrganizationRef:
       type: object
@@ -315,9 +313,7 @@ components:
         title:
           type: string
         other_id:
-          type: array
-          items:
-            $ref: "#/components/schemas/IdRef"
+          $ref: "#/components/schemas/IdRefs"
         organization:
           type: array
           items:
@@ -363,9 +359,7 @@ components:
         parent_id:
           type: string
         other_id:
-          type: array
-          items:
-            $ref: "#/components/schemas/IdRef"
+          $ref: "#/components/schemas/IdRefs"
       required: [id, date_created, date_updated, type]
 
     PersonListResponse:

--- a/api/v1/service.go
+++ b/api/v1/service.go
@@ -250,11 +250,8 @@ func mapToExternalPerson(person *models.Person) *Person {
 		}
 		p.Organization = append(p.Organization, oRef)
 	}
-	for _, otherId := range person.OtherId {
-		p.OtherID = append(p.OtherID, IdRef{
-			ID:   otherId.Id,
-			Type: otherId.Type,
-		})
+	if len(person.OtherId) > 0 {
+		p.OtherID = NewOptIdRefs(IdRefs(person.OtherId))
 	}
 	p.Role = append(p.Role, person.Role...)
 	if person.Settings != nil {
@@ -285,11 +282,8 @@ func mapToExternalOrganization(org *models.Organization) *Organization {
 	if org.NameEng != "" {
 		o.NameEng = NewOptString(org.NameEng)
 	}
-	for _, otherId := range org.OtherId {
-		o.OtherID = append(o.OtherID, IdRef{
-			ID:   otherId.Id,
-			Type: otherId.Type,
-		})
+	if len(org.OtherId) > 0 {
+		o.OtherID = NewOptIdRefs(IdRefs(org.OtherId))
 	}
 	if org.ParentId != "" {
 		o.ParentID = NewOptString(org.ParentId)

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -45,8 +45,7 @@ type OrganizationMutation struct {
 	_type                      *string
 	name_dut                   *string
 	name_eng                   *string
-	other_id                   *[]schema.IdRef
-	appendother_id             []schema.IdRef
+	other_id                   *schema.IdRefs
 	clearedFields              map[string]struct{}
 	people                     map[int]struct{}
 	removedpeople              map[int]struct{}
@@ -454,13 +453,12 @@ func (m *OrganizationMutation) ResetNameEng() {
 }
 
 // SetOtherID sets the "other_id" field.
-func (m *OrganizationMutation) SetOtherID(sr []schema.IdRef) {
+func (m *OrganizationMutation) SetOtherID(sr schema.IdRefs) {
 	m.other_id = &sr
-	m.appendother_id = nil
 }
 
 // OtherID returns the value of the "other_id" field in the mutation.
-func (m *OrganizationMutation) OtherID() (r []schema.IdRef, exists bool) {
+func (m *OrganizationMutation) OtherID() (r schema.IdRefs, exists bool) {
 	v := m.other_id
 	if v == nil {
 		return
@@ -471,7 +469,7 @@ func (m *OrganizationMutation) OtherID() (r []schema.IdRef, exists bool) {
 // OldOtherID returns the old "other_id" field's value of the Organization entity.
 // If the Organization object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *OrganizationMutation) OldOtherID(ctx context.Context) (v []schema.IdRef, err error) {
+func (m *OrganizationMutation) OldOtherID(ctx context.Context) (v schema.IdRefs, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldOtherID is only allowed on UpdateOne operations")
 	}
@@ -485,23 +483,9 @@ func (m *OrganizationMutation) OldOtherID(ctx context.Context) (v []schema.IdRef
 	return oldValue.OtherID, nil
 }
 
-// AppendOtherID adds sr to the "other_id" field.
-func (m *OrganizationMutation) AppendOtherID(sr []schema.IdRef) {
-	m.appendother_id = append(m.appendother_id, sr...)
-}
-
-// AppendedOtherID returns the list of values that were appended to the "other_id" field in this mutation.
-func (m *OrganizationMutation) AppendedOtherID() ([]schema.IdRef, bool) {
-	if len(m.appendother_id) == 0 {
-		return nil, false
-	}
-	return m.appendother_id, true
-}
-
 // ClearOtherID clears the value of the "other_id" field.
 func (m *OrganizationMutation) ClearOtherID() {
 	m.other_id = nil
-	m.appendother_id = nil
 	m.clearedFields[organization.FieldOtherID] = struct{}{}
 }
 
@@ -514,7 +498,6 @@ func (m *OrganizationMutation) OtherIDCleared() bool {
 // ResetOtherID resets all changes to the "other_id" field.
 func (m *OrganizationMutation) ResetOtherID() {
 	m.other_id = nil
-	m.appendother_id = nil
 	delete(m.clearedFields, organization.FieldOtherID)
 }
 
@@ -929,7 +912,7 @@ func (m *OrganizationMutation) SetField(name string, value ent.Value) error {
 		m.SetNameEng(v)
 		return nil
 	case organization.FieldOtherID:
-		v, ok := value.([]schema.IdRef)
+		v, ok := value.(schema.IdRefs)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -1948,8 +1931,7 @@ type PersonMutation struct {
 	active                     *bool
 	birth_date                 *string
 	email                      *string
-	other_id                   *[]schema.IdRef
-	appendother_id             []schema.IdRef
+	other_id                   *schema.IdRefs
 	first_name                 *string
 	full_name                  *string
 	last_name                  *string
@@ -2368,13 +2350,12 @@ func (m *PersonMutation) ResetEmail() {
 }
 
 // SetOtherID sets the "other_id" field.
-func (m *PersonMutation) SetOtherID(sr []schema.IdRef) {
+func (m *PersonMutation) SetOtherID(sr schema.IdRefs) {
 	m.other_id = &sr
-	m.appendother_id = nil
 }
 
 // OtherID returns the value of the "other_id" field in the mutation.
-func (m *PersonMutation) OtherID() (r []schema.IdRef, exists bool) {
+func (m *PersonMutation) OtherID() (r schema.IdRefs, exists bool) {
 	v := m.other_id
 	if v == nil {
 		return
@@ -2385,7 +2366,7 @@ func (m *PersonMutation) OtherID() (r []schema.IdRef, exists bool) {
 // OldOtherID returns the old "other_id" field's value of the Person entity.
 // If the Person object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PersonMutation) OldOtherID(ctx context.Context) (v []schema.IdRef, err error) {
+func (m *PersonMutation) OldOtherID(ctx context.Context) (v schema.IdRefs, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldOtherID is only allowed on UpdateOne operations")
 	}
@@ -2399,23 +2380,9 @@ func (m *PersonMutation) OldOtherID(ctx context.Context) (v []schema.IdRef, err 
 	return oldValue.OtherID, nil
 }
 
-// AppendOtherID adds sr to the "other_id" field.
-func (m *PersonMutation) AppendOtherID(sr []schema.IdRef) {
-	m.appendother_id = append(m.appendother_id, sr...)
-}
-
-// AppendedOtherID returns the list of values that were appended to the "other_id" field in this mutation.
-func (m *PersonMutation) AppendedOtherID() ([]schema.IdRef, bool) {
-	if len(m.appendother_id) == 0 {
-		return nil, false
-	}
-	return m.appendother_id, true
-}
-
 // ClearOtherID clears the value of the "other_id" field.
 func (m *PersonMutation) ClearOtherID() {
 	m.other_id = nil
-	m.appendother_id = nil
 	m.clearedFields[person.FieldOtherID] = struct{}{}
 }
 
@@ -2428,7 +2395,6 @@ func (m *PersonMutation) OtherIDCleared() bool {
 // ResetOtherID resets all changes to the "other_id" field.
 func (m *PersonMutation) ResetOtherID() {
 	m.other_id = nil
-	m.appendother_id = nil
 	delete(m.clearedFields, person.FieldOtherID)
 }
 
@@ -3483,7 +3449,7 @@ func (m *PersonMutation) SetField(name string, value ent.Value) error {
 		m.SetEmail(v)
 		return nil
 	case person.FieldOtherID:
-		v, ok := value.([]schema.IdRef)
+		v, ok := value.(schema.IdRefs)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/ent/organization.go
+++ b/ent/organization.go
@@ -34,7 +34,7 @@ type Organization struct {
 	// NameEng holds the value of the "name_eng" field.
 	NameEng string `json:"name_eng,omitempty"`
 	// OtherID holds the value of the "other_id" field.
-	OtherID []schema.IdRef `json:"other_id,omitempty"`
+	OtherID schema.IdRefs `json:"other_id,omitempty"`
 	// ParentID holds the value of the "parent_id" field.
 	ParentID int `json:"parent_id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.

--- a/ent/organization/organization.go
+++ b/ent/organization/organization.go
@@ -107,7 +107,7 @@ var (
 	// DefaultType holds the default value on creation for the "type" field.
 	DefaultType string
 	// DefaultOtherID holds the default value on creation for the "other_id" field.
-	DefaultOtherID []schema.IdRef
+	DefaultOtherID schema.IdRefs
 )
 
 // OrderOption defines the ordering options for the Organization queries.

--- a/ent/organization_create.go
+++ b/ent/organization_create.go
@@ -122,7 +122,7 @@ func (oc *OrganizationCreate) SetNillableNameEng(s *string) *OrganizationCreate 
 }
 
 // SetOtherID sets the "other_id" field.
-func (oc *OrganizationCreate) SetOtherID(sr []schema.IdRef) *OrganizationCreate {
+func (oc *OrganizationCreate) SetOtherID(sr schema.IdRefs) *OrganizationCreate {
 	oc.mutation.SetOtherID(sr)
 	return oc
 }

--- a/ent/organization_update.go
+++ b/ent/organization_update.go
@@ -10,7 +10,6 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/ugent-library/people-service/ent/organization"
 	"github.com/ugent-library/people-service/ent/organizationperson"
@@ -114,14 +113,8 @@ func (ou *OrganizationUpdate) ClearNameEng() *OrganizationUpdate {
 }
 
 // SetOtherID sets the "other_id" field.
-func (ou *OrganizationUpdate) SetOtherID(sr []schema.IdRef) *OrganizationUpdate {
+func (ou *OrganizationUpdate) SetOtherID(sr schema.IdRefs) *OrganizationUpdate {
 	ou.mutation.SetOtherID(sr)
-	return ou
-}
-
-// AppendOtherID appends sr to the "other_id" field.
-func (ou *OrganizationUpdate) AppendOtherID(sr []schema.IdRef) *OrganizationUpdate {
-	ou.mutation.AppendOtherID(sr)
 	return ou
 }
 
@@ -352,11 +345,6 @@ func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := ou.mutation.OtherID(); ok {
 		_spec.SetField(organization.FieldOtherID, field.TypeJSON, value)
-	}
-	if value, ok := ou.mutation.AppendedOtherID(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, organization.FieldOtherID, value)
-		})
 	}
 	if ou.mutation.OtherIDCleared() {
 		_spec.ClearField(organization.FieldOtherID, field.TypeJSON)
@@ -640,14 +628,8 @@ func (ouo *OrganizationUpdateOne) ClearNameEng() *OrganizationUpdateOne {
 }
 
 // SetOtherID sets the "other_id" field.
-func (ouo *OrganizationUpdateOne) SetOtherID(sr []schema.IdRef) *OrganizationUpdateOne {
+func (ouo *OrganizationUpdateOne) SetOtherID(sr schema.IdRefs) *OrganizationUpdateOne {
 	ouo.mutation.SetOtherID(sr)
-	return ouo
-}
-
-// AppendOtherID appends sr to the "other_id" field.
-func (ouo *OrganizationUpdateOne) AppendOtherID(sr []schema.IdRef) *OrganizationUpdateOne {
-	ouo.mutation.AppendOtherID(sr)
 	return ouo
 }
 
@@ -908,11 +890,6 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 	}
 	if value, ok := ouo.mutation.OtherID(); ok {
 		_spec.SetField(organization.FieldOtherID, field.TypeJSON, value)
-	}
-	if value, ok := ouo.mutation.AppendedOtherID(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, organization.FieldOtherID, value)
-		})
 	}
 	if ouo.mutation.OtherIDCleared() {
 		_spec.ClearField(organization.FieldOtherID, field.TypeJSON)

--- a/ent/person.go
+++ b/ent/person.go
@@ -34,7 +34,7 @@ type Person struct {
 	// Email holds the value of the "email" field.
 	Email string `json:"email,omitempty"`
 	// OtherID holds the value of the "other_id" field.
-	OtherID []schema.IdRef `json:"other_id,omitempty"`
+	OtherID schema.IdRefs `json:"other_id,omitempty"`
 	// FirstName holds the value of the "first_name" field.
 	FirstName string `json:"first_name,omitempty"`
 	// FullName holds the value of the "full_name" field.

--- a/ent/person/person.go
+++ b/ent/person/person.go
@@ -131,7 +131,7 @@ var (
 	// DefaultActive holds the default value on creation for the "active" field.
 	DefaultActive bool
 	// DefaultOtherID holds the default value on creation for the "other_id" field.
-	DefaultOtherID []schema.IdRef
+	DefaultOtherID schema.IdRefs
 	// DefaultJobCategory holds the default value on creation for the "job_category" field.
 	DefaultJobCategory []string
 	// DefaultRole holds the default value on creation for the "role" field.

--- a/ent/person_create.go
+++ b/ent/person_create.go
@@ -122,7 +122,7 @@ func (pc *PersonCreate) SetNillableEmail(s *string) *PersonCreate {
 }
 
 // SetOtherID sets the "other_id" field.
-func (pc *PersonCreate) SetOtherID(sr []schema.IdRef) *PersonCreate {
+func (pc *PersonCreate) SetOtherID(sr schema.IdRefs) *PersonCreate {
 	pc.mutation.SetOtherID(sr)
 	return pc
 }

--- a/ent/person_update.go
+++ b/ent/person_update.go
@@ -114,14 +114,8 @@ func (pu *PersonUpdate) ClearEmail() *PersonUpdate {
 }
 
 // SetOtherID sets the "other_id" field.
-func (pu *PersonUpdate) SetOtherID(sr []schema.IdRef) *PersonUpdate {
+func (pu *PersonUpdate) SetOtherID(sr schema.IdRefs) *PersonUpdate {
 	pu.mutation.SetOtherID(sr)
-	return pu
-}
-
-// AppendOtherID appends sr to the "other_id" field.
-func (pu *PersonUpdate) AppendOtherID(sr []schema.IdRef) *PersonUpdate {
-	pu.mutation.AppendOtherID(sr)
 	return pu
 }
 
@@ -532,11 +526,6 @@ func (pu *PersonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := pu.mutation.OtherID(); ok {
 		_spec.SetField(person.FieldOtherID, field.TypeJSON, value)
 	}
-	if value, ok := pu.mutation.AppendedOtherID(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, person.FieldOtherID, value)
-		})
-	}
 	if pu.mutation.OtherIDCleared() {
 		_spec.ClearField(person.FieldOtherID, field.TypeJSON)
 	}
@@ -838,14 +827,8 @@ func (puo *PersonUpdateOne) ClearEmail() *PersonUpdateOne {
 }
 
 // SetOtherID sets the "other_id" field.
-func (puo *PersonUpdateOne) SetOtherID(sr []schema.IdRef) *PersonUpdateOne {
+func (puo *PersonUpdateOne) SetOtherID(sr schema.IdRefs) *PersonUpdateOne {
 	puo.mutation.SetOtherID(sr)
-	return puo
-}
-
-// AppendOtherID appends sr to the "other_id" field.
-func (puo *PersonUpdateOne) AppendOtherID(sr []schema.IdRef) *PersonUpdateOne {
-	puo.mutation.AppendOtherID(sr)
 	return puo
 }
 
@@ -1285,11 +1268,6 @@ func (puo *PersonUpdateOne) sqlSave(ctx context.Context) (_node *Person, err err
 	}
 	if value, ok := puo.mutation.OtherID(); ok {
 		_spec.SetField(person.FieldOtherID, field.TypeJSON, value)
-	}
-	if value, ok := puo.mutation.AppendedOtherID(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, person.FieldOtherID, value)
-		})
 	}
 	if puo.mutation.OtherIDCleared() {
 		_spec.ClearField(person.FieldOtherID, field.TypeJSON)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -43,7 +43,7 @@ func init() {
 	// organizationDescOtherID is the schema descriptor for other_id field.
 	organizationDescOtherID := organizationFields[4].Descriptor()
 	// organization.DefaultOtherID holds the default value on creation for the other_id field.
-	organization.DefaultOtherID = organizationDescOtherID.Default.([]schema.IdRef)
+	organization.DefaultOtherID = organizationDescOtherID.Default.(schema.IdRefs)
 	organizationpersonMixin := schema.OrganizationPerson{}.Mixin()
 	organizationpersonMixinFields0 := organizationpersonMixin[0].Fields()
 	_ = organizationpersonMixinFields0
@@ -97,7 +97,7 @@ func init() {
 	// personDescOtherID is the schema descriptor for other_id field.
 	personDescOtherID := personFields[4].Descriptor()
 	// person.DefaultOtherID holds the default value on creation for the other_id field.
-	person.DefaultOtherID = personDescOtherID.Default.([]schema.IdRef)
+	person.DefaultOtherID = personDescOtherID.Default.(schema.IdRefs)
 	// personDescJobCategory is the schema descriptor for job_category field.
 	personDescJobCategory := personFields[8].Descriptor()
 	// person.DefaultJobCategory holds the default value on creation for the job_category field.

--- a/ent/schema/organization.go
+++ b/ent/schema/organization.go
@@ -43,7 +43,7 @@ func (Organization) Fields() []ent.Field {
 		field.String("type").Default("organization"),
 		field.String("name_dut").Optional(),
 		field.String("name_eng").Optional(),
-		field.JSON("other_id", []IdRef{}).Optional().Default([]IdRef{}),
+		field.JSON("other_id", IdRefs{}).Optional().Default(IdRefs{}),
 		field.Int("parent_id").Optional(),
 	}
 }

--- a/ent/schema/person.go
+++ b/ent/schema/person.go
@@ -14,10 +14,7 @@ type Person struct {
 	ent.Schema
 }
 
-type IdRef struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
+type IdRefs map[string][]string
 
 // TODO validate type
 var PersonIdTypes = []string{
@@ -42,7 +39,7 @@ func (Person) Fields() []ent.Field {
 		field.Bool("active").Default(false),
 		field.String("birth_date").Optional(),
 		field.String("email").Optional(),
-		field.JSON("other_id", []IdRef{}).Optional().Default([]IdRef{}),
+		field.JSON("other_id", IdRefs{}).Optional().Default(IdRefs{}),
 		field.String("first_name").Optional(),
 		field.String("full_name").Optional(),
 		field.String("last_name").Optional(),

--- a/models/id_ref.go
+++ b/models/id_ref.go
@@ -1,6 +1,0 @@
-package models
-
-type IdRef struct {
-	Id   string `json:"id,omitempty"`
-	Type string `json:"type,omitempty"`
-}

--- a/models/id_refs.go
+++ b/models/id_refs.go
@@ -1,0 +1,3 @@
+package models
+
+type IdRefs map[string][]string

--- a/models/organization.go
+++ b/models/organization.go
@@ -11,7 +11,7 @@ type Organization struct {
 	NameDut     string     `json:"name_dut,omitempty"`
 	NameEng     string     `json:"name_eng,omitempty"`
 	ParentId    string     `json:"parent_id,omitempty"`
-	OtherId     []*IdRef   `json:"other_id,omitempty"`
+	OtherId     IdRefs     `json:"other_id,omitempty"`
 }
 
 func (org *Organization) IsStored() bool {
@@ -19,5 +19,7 @@ func (org *Organization) IsStored() bool {
 }
 
 func NewOrganization() *Organization {
-	return &Organization{}
+	org := &Organization{}
+	org.OtherId = IdRefs{}
+	return org
 }

--- a/models/organization_service.go
+++ b/models/organization_service.go
@@ -9,7 +9,7 @@ type OrganizationService interface {
 	GetOrganization(context.Context, string) (*Organization, error)
 	GetOrganizationByGismoId(context.Context, string) (*Organization, error)
 	GetOrganizationsByGismoId(context.Context, ...string) ([]*Organization, error)
-	GetOrganizationByOtherId(context.Context, string, string) (*Organization, error)
+	GetOrganizationByOtherId(context.Context, string, ...string) (*Organization, error)
 	DeleteOrganization(context.Context, string) error
 	EachOrganization(context.Context, func(*Organization) bool) error
 	GetOrganizations(context.Context) ([]*Organization, string, error)

--- a/models/person.go
+++ b/models/person.go
@@ -20,7 +20,7 @@ type Person struct {
 	PreferredLastName  string             `json:"preferred_last_name,omitempty"`
 	BirthDate          string             `json:"birth_date,omitempty"`
 	Title              string             `json:"title,omitempty"`
-	OtherId            []*IdRef           `json:"other_id,omitempty"`
+	OtherId            IdRefs             `json:"other_id,omitempty"`
 	Organization       []*OrganizationRef `json:"organization,omitempty"`
 	JobCategory        []string           `json:"job_category,omitempty"`
 	Role               []string           `json:"role,omitempty"`
@@ -34,7 +34,9 @@ func (person *Person) IsStored() bool {
 }
 
 func NewPerson() *Person {
-	return &Person{}
+	p := &Person{}
+	p.OtherId = IdRefs{}
+	return p
 }
 
 func NewOrganizationRef(id string) *OrganizationRef {

--- a/models/person_service.go
+++ b/models/person_service.go
@@ -9,7 +9,7 @@ type PersonService interface {
 	CreatePerson(context.Context, *Person) (*Person, error)
 	UpdatePerson(context.Context, *Person) (*Person, error)
 	GetPerson(context.Context, string) (*Person, error)
-	GetPersonByOtherId(context.Context, string, string) (*Person, error)
+	GetPersonByOtherId(context.Context, string, ...string) (*Person, error)
 	GetPersonByGismoId(context.Context, string) (*Person, error)
 	DeletePerson(context.Context, string) error
 	EachPerson(context.Context, func(*Person) bool) error

--- a/repository/common.go
+++ b/repository/common.go
@@ -127,7 +127,7 @@ func customSchemaChanges(next schema.Applier) schema.Applier {
 		ALTER TABLE organization
 		ADD COLUMN IF NOT EXISTS ts tsvector GENERATED ALWAYS AS
 		(
-			to_tsvector('simple', jsonb_path_query_array(other_id, '$[*].id')) ||
+			to_tsvector('simple', jsonb_path_query_array(other_id,'$.**{2}')) ||
 			to_tsvector('simple', public_id) ||
 			to_tsvector('usimple',name_dut) ||
 			to_tsvector('usimple', name_eng)


### PR DESCRIPTION
Fixes #37 

- rewritten `OtherId` from an array of `IdRef` (with attribute `Type` and `Value`) to a `map[string][]string` where the key is the type. So basically a conversion from `[{"type": "ugent_id", "value": "12334"}, {"type": "ugent_id", "value": "12335"}]` to `{"ugent_id": ["12334", "12335"]}`. See `models.IdRefs` (plural!). Derivative models in package `schema` (for ent) and `api` (for the openapi) also converted. Made use of automatic conversion between compatible models (e.g. `models.IdRefs(otherId)`)
- see changes in `api/v1/service.go` and `api/v1/openapi.yml`. Rest in `api/v1` is generated code
- see changes in `ent/schema`. Rest in `ent/` is generated code
- `repository.GetOrganizationByOtherId(ctx, typ, val)` has been changed to  `repository.GetOrganizationByOtherId(ctx, typ, ...values)` in order to accept a list of possible id's to match. This shortens the client, where I previously looped over every value and called this method.
- same goes for method `repository.GetPersonByOtherId` 

Notes:

- `models.IdRefs` is a separate type so I could add sugar methods like  `Add(typ, val)` or `Remove(type, val)` to shorten assignments
- I could also call it `models.Identifiers` like was done in biblio-backoffice: https://github.com/ugent-library/biblio-backoffice/blob/dev/internal/models/identifiers.go#L3. But not sure if you were all happy about that.